### PR TITLE
feat: support reduce sum

### DIFF
--- a/cim_compiler/csrc/passes/LoopUnrollPass.cpp
+++ b/cim_compiler/csrc/passes/LoopUnrollPass.cpp
@@ -90,8 +90,9 @@ struct LoopUnrollPass
         int64_t lbCst = lbCstOp.value();
         int64_t ubCst = ubCstOp.value();
         int64_t stepCst = stepCstOp.value();
-        if (stepCst == 1) {
-          int64_t unrollFactor = (ubCst - lbCst) / stepCst;
+        if (stepCst >= 1) {
+          int64_t unrollFactor = (ubCst - lbCst - 1) / stepCst + 1;
+          LOG_INFO << "LoopUnrollPass lbCst=" << lbCst << " ubCst=" << ubCst << " stepCst=" << stepCst << " unrollFactor: " << unrollFactor << std::endl;
           if (!failed(mlir::loopUnrollByFactor(forOp, unrollFactor))) {
             fail_cnt -= 1;
           }

--- a/cim_compiler/op/reduce/reduce_sum.cim
+++ b/cim_compiler/op/reduce/reduce_sum.cim
@@ -1,0 +1,27 @@
+def reduce_sum(
+    vector_in< <-1>, fp16, __OUTPUT_MEMORY__>,
+    vector_out< <-1>, fp16, __OUTPUT_MEMORY__>
+) {
+    reduce_len = {{reduce_config.reduce_len}};
+    reduce_num = {{reduce_config.reduce_num}};
+    big_from = reduce_len * reduce_num;
+    N = Shape(vector_in, 0);
+    M = Shape(vector_out, 0);
+    // assert M = ceil(N/reduce_len)
+    n_step = div_ceil(N, big_from);
+
+    use_vector_out_size = 0;
+    @unroll
+    for i in range(0, n_step) carry (use_vector_out_size) {
+        src_vector_len = Min(big_from, N-i*big_from);
+        src_vector = vector_in[i*big_from:i*big_from+src_vector_len];
+
+        dst_vector_len = div_ceil(src_vector_len, reduce_len);
+        dst_vector = vector_out[i*reduce_num:i*reduce_num+dst_vector_len];
+        SIMD(REDUCE_SUM, src_vector, dst_vector);
+
+        use_vector_out_size = i*reduce_num+dst_vector_len;
+    };
+
+    reduce_sum_inplace(vector_out[:use_vector_out_size]); // save at vector_out[-1]
+}

--- a/cim_compiler/op/reduce/reduce_sum_inplace.cim
+++ b/cim_compiler/op/reduce/reduce_sum_inplace.cim
@@ -1,0 +1,48 @@
+def div_ceil(
+    a<index>,
+    b<index>
+) {
+    return ((a - 1) / b) + 1;
+}
+
+def reduce_sum_inplace(
+    vector< <-1>, fp16, __OUTPUT_MEMORY__>
+) {
+    reduce_len = {{reduce_config.reduce_len}};
+    reduce_num = {{reduce_config.reduce_num}};
+    big_from = reduce_len * reduce_num;
+    N = Shape(vector, 0);
+
+    // stage 1
+    
+    stage_1_size = (N - big_from) + 1;
+    stage_1_step = big_from - reduce_num;
+    @unroll
+    for i in range(0, stage_1_size, stage_1_step) carry () {
+        src_vector = vector[i:i+big_from];
+        dst_vector = vector[i+big_from-reduce_num:i+big_from];
+        SIMD(REDUCE_SUM, src_vector, dst_vector);
+    };
+
+    max_i = div_ceil(stage_1_size, stage_1_step) - 1;
+    stage_2_begin = (( max_i * stage_1_step) + big_from) - reduce_num;
+    // Results of stage 1 are in vector[stage_2_begin: N]
+
+    // stage 2
+    k = N - stage_2_begin;
+
+    stage_2_steps = {{1 + math.ceil(math.log(reduce_config.reduce_num) / math.log(reduce_config.reduce_len))}};
+    @unroll
+    for i in range(0, stage_2_steps) carry (k) {
+        if (k >= 2) carry () {
+            src_vector = vector[stage_2_begin:stage_2_begin+k];
+            next_k = div_ceil(k, reduce_len);
+            dst_vector = vector[stage_2_begin:stage_2_begin+next_k];
+            SIMD(REDUCE_SUM, src_vector, dst_vector);
+        } else {
+            do_nothing = 1;
+        };
+        k = div_ceil(k, reduce_len);
+    };
+    Trans(vector[stage_2_begin], vector[0]);
+}

--- a/cim_compiler/simulator/reduce_util.py
+++ b/cim_compiler/simulator/reduce_util.py
@@ -1,0 +1,39 @@
+import numpy as np
+import json
+
+from cim_compiler.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class ReduceSumConfig:
+    def __init__(self, reduce_len, reduce_num):
+        self.reduce_len = reduce_len
+        self.reduce_num = reduce_num
+        logger.debug(f"Mask config: {reduce_len=}, {reduce_num=}")
+
+    @classmethod
+    def from_config(cls, config_path):
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        return cls(config.get("reduce", {}).get("reduce_len", None), config.get("reduce", {}).get("reduce_num", None))
+
+class ReduceSumUtil:
+    def __init__(self, reduce_sum_config):
+        self.reduce_sum_config = reduce_sum_config
+        self.reduce_len = reduce_sum_config.reduce_len
+        self.reduce_num = reduce_sum_config.reduce_num
+
+    def reduce_sum(self, src_vector):
+        if self.reduce_sum_config is None or self.reduce_len is None or self.reduce_num is None:
+            assert False, "Reduce sum config is not set"
+        assert len(src_vector.shape) == 1
+        assert src_vector.shape[0] <= self.reduce_len * self.reduce_num
+        # pad src_vector to the nearest multiple of reduce_len
+        N = src_vector.shape[0]
+        pad_len = (self.reduce_len - N % self.reduce_len) % self.reduce_len
+        src_vector = np.pad(src_vector, (0, pad_len), mode='constant')
+        N = src_vector.shape[0]
+        src_vector = src_vector.reshape(N // self.reduce_len, self.reduce_len)
+        dst_vector = src_vector.sum(axis=1)
+        dst_vector = dst_vector.reshape(-1)
+        return dst_vector

--- a/test/base.py
+++ b/test/base.py
@@ -17,6 +17,8 @@ class OpRunner:
     def run(self, input_list:list[np.ndarray], output_list:list[np.ndarray]):
         
         with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = os.environ.get("CIM_COMPILER_OUTPUT_DIR", tmp_dir)
+            os.makedirs(tmp_dir, exist_ok=True)
             # tmp_dir = "/home/wangyiou/project/CIMCompiler/.temp"
             op_code_path = os.path.join(tmp_dir, "op_code.cim")
             final_code_dir = os.path.join(tmp_dir, "compiler_output")

--- a/test/op/test_reduce/test_reduce.cim
+++ b/test/op/test_reduce/test_reduce.cim
@@ -1,0 +1,25 @@
+{% include 'op/common/def_special_regs.cim' %}
+{% include 'op/common/simd.cim' %}
+{% include 'op/reduce/reduce_sum_inplace.cim' %}
+{% include 'op/reduce/reduce_sum.cim' %}
+
+def set_special_regs(){
+    SpecialRegSet(SPECIAL_REG_SIMD_INPUT_1_BIT_WIDTH, 16);
+    SpecialRegSet(SPECIAL_REG_SIMD_INPUT_2_BIT_WIDTH, 16);
+    SpecialRegSet(SPECIAL_REG_SIMD_OUTPUT_BIT_WIDTH, 16);
+
+    SpecialRegSet(SPECIAL_REG_DTYPE_SIMD_IS_FLOAT, 1);
+}
+
+def main(){
+    set_special_regs();
+    
+    x_global = Buffer(<{{vector_len}}>, fp16, __GLOBAL__);
+    x_local = Buffer(<{{vector_len}}>, fp16, __OUTPUT_MEMORY__);
+    x_local_2 = Buffer(<{{vector_len}}>, fp16, __OUTPUT_MEMORY__);
+    sum_x_global = Buffer(<1>, fp16, __GLOBAL__);
+    Trans(x_global, x_local);
+    reduce_sum(x_local, x_local_2);
+    sum_x_local = x_local_2[0];
+    Trans(sum_x_local, sum_x_global);
+}

--- a/test/op/test_reduce/test_reduce.py
+++ b/test/op/test_reduce/test_reduce.py
@@ -1,0 +1,131 @@
+import os
+import json
+import numpy as np
+from dataclasses import dataclass
+from test.base import OpRunner
+import math
+import tempfile
+import shutil
+import pytest
+
+@dataclass
+class ReduceOpConfig:
+    reduce_num: int
+    reduce_len: int
+
+@dataclass
+class ReduceTestConfig:
+    reduce_config: ReduceOpConfig
+    vector_len: int
+    math: str
+
+def get_reduce_config(cim_config_path):
+    with open(cim_config_path, "r") as f:
+        config = json.load(f)
+    return ReduceOpConfig(
+        reduce_num=config["reduce"]["reduce_num"],
+        reduce_len=config["reduce"]["reduce_len"]
+    )
+
+class ModifyReduceConfig:
+    def __init__(self, base_config_path, reduce_len, reduce_num):
+        self.base_config_path = base_config_path
+        self.reduce_len = reduce_len
+        self.reduce_num = reduce_num
+
+    def __enter__(self):
+        # read base config
+        with open(self.base_config_path, "r") as f:
+            self.base_config = json.load(f)
+        
+        # modify reduce config
+        self.modified_config = self.base_config.copy()
+        self.modified_config["reduce"] = {}
+        self.modified_config["reduce"]["reduce_len"] = self.reduce_len
+        self.modified_config["reduce"]["reduce_num"] = self.reduce_num
+
+        # create temp config file in a temp dir
+        self.modified_config_path = tempfile.mktemp()
+        with open(self.modified_config_path, "w") as f:
+            json.dump(self.modified_config, f)
+        return self  # 可以返回一个对象，供 `as` 关键字使用
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # clear modified_config_path
+        os.remove(self.modified_config_path)
+        return False  # 返回 False 表示异常未处理，会继续传播
+
+# @pytest.mark.parametrize(
+#     "vector_len, reduce_num, reduce_len",
+#     [
+#         (vector_len, reduce_num, reduce_len)
+#         for vector_len in [1, 2, 4, 8]#, 16, 32, 64, 128, 256, 512, 1024, 2048]
+#         for reduce_num in [1, 2, 4, 8, 16, 32]
+#         for reduce_len in [2, 4, 8, 16, 32]
+#     ],
+# )
+# def test_reduce_inplace(vector_len, reduce_num, reduce_len):
+#     cim_compiler_home = os.environ["CIM_COMPILER_BASE"]
+#     op_path = os.path.join(cim_compiler_home, "test/op/test_reduce/test_reduce_inplace.cim")
+#     cim_config_path = os.path.join(cim_compiler_home, "test/op/llm/config.json")
+#     with ModifyReduceConfig(cim_config_path, reduce_len, reduce_num) as m:
+
+#         op_config = ReduceTestConfig(
+#             vector_len=vector_len,
+#             reduce_config=get_reduce_config(m.modified_config_path),
+#             math=math
+#         )
+
+#         op_runner = OpRunner(op_path, op_config, m.modified_config_path)
+
+#         """
+#         x_global = Buffer(<{{seqlen}}>, fp16, __GLOBAL__);
+#         """
+#         x = np.random.randint(-2,3, (op_config.vector_len,)).astype(np.float16)
+#         # x = np.zeros((op_config.vector_len,), dtype=np.float16) + 1
+#         output = np.zeros((1,), dtype=np.float16)
+        
+#         golden = x.sum()
+#         op_runner.run([x], [output])
+
+#     allclose = np.allclose(output, golden, rtol=1e-2, atol=1e-2)
+#     print(f"{allclose=}")
+
+@pytest.mark.parametrize(
+    "vector_len, reduce_num, reduce_len",
+    [
+        (vector_len, reduce_num, reduce_len)
+        for vector_len in [1, 2, 4, 512, 1024, 2048]
+        for reduce_num in [1, 2, 4, 8, 16, 32]
+        for reduce_len in [2, 4, 8, 16, 32]
+    ],
+)
+def test_reduce(vector_len, reduce_num, reduce_len):
+    cim_compiler_home = os.environ["CIM_COMPILER_BASE"]
+    op_path = os.path.join(cim_compiler_home, "test/op/test_reduce/test_reduce.cim")
+    cim_config_path = os.path.join(cim_compiler_home, "test/op/llm/config.json")
+    with ModifyReduceConfig(cim_config_path, reduce_len, reduce_num) as m:
+
+        op_config = ReduceTestConfig(
+            vector_len=vector_len,
+            reduce_config=get_reduce_config(m.modified_config_path),
+            math=math
+        )
+
+        op_runner = OpRunner(op_path, op_config, m.modified_config_path)
+
+        """
+        x_global = Buffer(<{{seqlen}}>, fp16, __GLOBAL__);
+        """
+        x = np.random.randint(-2,3, (op_config.vector_len,)).astype(np.float16)
+        # x = np.zeros((op_config.vector_len,), dtype=np.float16) + 1
+        output = np.zeros((1,), dtype=np.float16)
+        
+        golden = x.sum()
+        op_runner.run([x], [output])
+
+    allclose = np.allclose(output, golden, rtol=1e-2, atol=1e-2)
+    print(f"{allclose=}")
+
+if __name__=="__main__":
+    test_reduce(16, 1, 4)

--- a/test/op/test_reduce/test_reduce_inplace.cim
+++ b/test/op/test_reduce/test_reduce_inplace.cim
@@ -1,0 +1,23 @@
+{% include 'op/common/def_special_regs.cim' %}
+{% include 'op/common/simd.cim' %}
+{% include 'op/reduce/reduce_sum_inplace.cim' %}
+
+def set_special_regs(){
+    SpecialRegSet(SPECIAL_REG_SIMD_INPUT_1_BIT_WIDTH, 16);
+    SpecialRegSet(SPECIAL_REG_SIMD_INPUT_2_BIT_WIDTH, 16);
+    SpecialRegSet(SPECIAL_REG_SIMD_OUTPUT_BIT_WIDTH, 16);
+
+    SpecialRegSet(SPECIAL_REG_DTYPE_SIMD_IS_FLOAT, 1);
+}
+
+def main(){
+    set_special_regs();
+    
+    x_global = Buffer(<{{vector_len}}>, fp16, __GLOBAL__);
+    x_local = Buffer(<{{vector_len}}>, fp16, __OUTPUT_MEMORY__);
+    sum_x_global = Buffer(<1>, fp16, __GLOBAL__);
+    Trans(x_global, x_local);
+    reduce_sum_inplace(x_local);
+    sum_x_local = x_local[0];
+    Trans(sum_x_local, sum_x_global);
+}


### PR DESCRIPTION
In the config file:
```
{
  ...
  "reduce":{
    "reduce_num": xxx,
    "reduce_len": xxx 
  }
}
```

- `reduce_num`: The number of reduce sum units.
- `reduce_len`: The length of summation that each reduce sum unit can perform.

A SIMD `reduce_sum` instruction completes a summation of length `reduce_num * reduce_len` and reduces it to `reduce_num` results.